### PR TITLE
feat(consumer): Add Delete units for drupal.product.node and drupal.p…

### DIFF
--- a/connector_drupal_ecommerce/product.py
+++ b/connector_drupal_ecommerce/product.py
@@ -32,6 +32,7 @@ from .backend import drupal
 from .connector import get_environment
 from .related_action import unwrap_binding
 from .unit.export_synchronizer import DrupalExporter
+from .unit.delete_synchronizer import DrupalDeleteSynchronizer
 from .unit.backend_adapter import DrupalCRUDAdapter
 
 
@@ -232,6 +233,13 @@ class ProductProductAdapter(DrupalCRUDAdapter):
     def update_inventory(self, id, data):
         """ Write updated inventory on Drupal product """
         return self.write(id, data)
+
+
+@drupal
+class ProductProductDeleter(DrupalDeleteSynchronizer):
+    _model_name = 'drupal.product.product'
+    _drupal_model = 'product'
+
 
 # fields which should not trigger an export of the products
 # but an export of their inventory

--- a/drupal_export_product/consumer.py
+++ b/drupal_export_product/consumer.py
@@ -47,6 +47,8 @@ def delay_export_node_bindings(session, model_name, record_id, vals):
         session, model_name, record_id, vals
     )
 
-@on_record_unlink(model_names=['drupal.product.node', 'drupal.product.category'])
+@on_record_unlink(model_names=['drupal.product.node',
+                               'drupal.product.product',
+                               'drupal.product.category'])
 def delay_unlink(session, model_name, record_id):
     drupalconnect.delay_unlink(session, model_name, record_id)

--- a/drupal_export_product/models/product.py
+++ b/drupal_export_product/models/product.py
@@ -166,6 +166,12 @@ class ProductNodeAdapter(DrupalCRUDAdapter):
         return result['nid']
 
 
+@drupal
+class ProductNodeDeleter(DrupalDeleteSynchronizer):
+    _model_name = 'drupal.product.node'
+    _drupal_model = 'node'
+
+
 class product_category(orm.Model):
     _inherit = 'product.category'
 


### PR DESCRIPTION
…roduct.product

There were missing delete unit classes for drupal.product.product and drupal.product.node causing
errores when trying to delete drupal products and nodes from connector
