### PR TITLE
fix(drupal_export_product): add ondelete cascade for drupal vocabulary

### DIFF
--- a/drupal_export_product/models/drupal_model.py
+++ b/drupal_export_product/models/drupal_model.py
@@ -41,7 +41,7 @@ class drupal_backend(orm.Model):
 
     _columns = {
         'drupal_vocabulary_id': fields.many2one(
-            'drupal.vocabulary', 'Vocabulary'
+            'drupal.vocabulary', 'Vocabulary', ondelete='cascade',
         ),
         'main_product_category_id': fields.many2one(
             'product.category', 'Main product category'


### PR DESCRIPTION
With this correction it will be allowed to delete the drupal vocabulary connectors and the registers
associated with this vocabulary